### PR TITLE
DepCard: Push the border rect beneath the icon/text

### DIFF
--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -124,6 +124,10 @@ class DepCard extends PureComponent {
         rx={radius} ry={radius} style={backgroundStyle}>
       </rect>
       <path d={taskPath.join(' ')} style={taskStyle} />
+      <rect
+        x={left} y={top} width={width} height={height}
+        rx={radius} ry={radius} style={style}>
+      </rect>
       <a xlinkHref={host}>
         <image
           x={leftCenter} y={this.props.cy - 0.4 * height}
@@ -138,10 +142,6 @@ class DepCard extends PureComponent {
           {this.props.slug.replace(/^[^\/]*\//, '')}
         </text>
       </a>
-      <rect
-        x={left} y={top} width={width} height={height}
-        rx={radius} ry={radius} style={style}>
-      </rect>
       <DepIndicators
         cx={right} cy={this.props.cy} dy={height/2}
         blockers={this.props.blockers}


### PR DESCRIPTION
I'd shifted this in #18 with some rough thoughts about clipping long slugs so they don't overflow the card.  But it meant that the border rect masked the links provided by the icon and text.  This commit shifts the border rect lower in the stack so you can get a click through to the active elements again.  We'll need a more robust solution to clipping/overflow anyway.