### PR TITLE
.travis.yml: Configure Travis to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: node_js
+node_js:
+  - node
+cache:
+  directories:
+    - node_modules
+install:
+  - (cd webapp && npm install)
+script:
+  - bash -c 'set -e -o pipefail; (cd webapp && CI=1 npm test -- --coverage) | tee test.out'
+  - sed -n 's/All files *| *\([0-9][0-9.]*\) .*/\1/p' test.out >coverage
+  - cat coverage
+  - test 100 = $(cat coverage)


### PR DESCRIPTION
Docs [here][1] and [here][2].  The sed/test stuff ensures we keep 100% coverage.  There is some machine-oriented coverage output in:

    $ npm test -- --coverage --json --jsonOutputFile test.json

but it looks like the lines covered by each suite, when I'm more interested in the lines *not* covered by the entire harness.

Probably best to not merge this until we know it works ;).

Fixes #23.

[1]: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
[2]: https://github.com/facebookincubator/create-react-app/blob/v0.7.0/packages/react-scripts/template/README.md#continuous-integration