### PR TITLE
Home: Set overflow-y to auto for scrolling on small windows

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -15,14 +15,20 @@ Getters['dummy'] = dummyGetter.GetNodes.bind(dummyGetter);
 Canonicalizers['github.com'] = CanonicalGitHubKey;
 Getters['github.com'] = GetGitHubNodes;
 
-export class DepGraphView extends Component {
-  getSize() {
-    return {
-      height: window.innerHeight - HeaderHeight,
-      width: window.innerWidth,
-    }
+function getSize() {
+  return {
+    height: window.innerHeight - HeaderHeight,
+    width: window.innerWidth,
   }
+}
 
+export class HomeView extends Component {
+  render() {
+    return <Home getSize={getSize} />
+  }
+}
+
+export class DepGraphView extends Component {
   expanded() {
     return (
       this.props.location &&
@@ -50,7 +56,7 @@ export class DepGraphView extends Component {
 
   render() {
     return <DepGraph
-      getSize={this.getSize.bind(this)}
+      getSize={getSize}
       getNodes={this.getNodes.bind(this)} canonicalKey={CanonicalKey}
       slugs={[this.props.params.splat]}
       onKeyPress={this.handleKeyPress.bind(this)} />
@@ -73,7 +79,7 @@ class App extends Component {
       <div className="App">
         <Router history={hashHistory}>
           <Route path="/" component={Layout}>
-            <IndexRoute component={Home} />
+            <IndexRoute component={HomeView} />
             <Route path="/http/*" component={DepGraphView}
               onEnter={enterGraphView} />
           </Route>

--- a/webapp/src/App.test.js
+++ b/webapp/src/App.test.js
@@ -16,6 +16,14 @@ it('issue view renders without crashing', () => {
   );
 });
 
+it('issue view renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <DepGraphView params={{'splat': 'dummy/jbenet/depviz/30'}} />,
+    div
+  );
+});
+
 it('entering graph view normalizes non-canonical paths', () => {
   const div = document.createElement('div');
   ReactDOM.render(

--- a/webapp/src/Home.css
+++ b/webapp/src/Home.css
@@ -1,6 +1,7 @@
 .Home {
-  padding-left: 1em;
-  padding-right: 1em;
+  padding-left: 10px;
+  padding-right: 10px;
+  overflow-y: auto;
 }
 
 .Home-logo {

--- a/webapp/src/Home.js
+++ b/webapp/src/Home.js
@@ -4,8 +4,46 @@ import github from './logo/github.svg';
 import './Home.css';
 
 class Home extends PureComponent {
+  constructor(props) {
+    super(props);
+    var size;
+    if (this.props.getSize) {
+      size = this.props.getSize();
+    } else {
+      size = {width: 400, height: 400};
+    }
+    this.state = {
+      width: size.width,
+      height: size.height,
+    };
+    this.updateDimensions = this.updateDimensions.bind(this);
+  }
+
+  updateDimensions() {
+    var size;
+    if (this.props.getSize) {
+      size = this.props.getSize();
+    } else {
+      size = {width: 400, height: 400};
+    }
+    this.setState({width: size.width, height: size.height});
+  }
+
+  componentWillMount() {
+    this.updateDimensions();
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.updateDimensions);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateDimensions);
+  }
+
   render() {
-    return <div className="Home">
+    return <div className="Home"
+        style={{height: this.state.height, width: this.state.width - 20}}>
       <h2 id="identifiers">Identifiers</h2>
 
       <p>

--- a/webapp/src/Home.test.js
+++ b/webapp/src/Home.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Home from './Home';
+
+it('home page without size renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Home />, div);
+});


### PR DESCRIPTION
For example, my cell phone screen is not big enough to see the whole intro.  There's a bit of shuffling around to set an explicit height and width, without which Firefox doesn't seem to want to set the scrollbar.