### PR TITLE
DepIndicators: Add pie-chart completion to the dependencies indicator

### DIFF
--- a/webapp/src/Color.js
+++ b/webapp/src/Color.js
@@ -1,3 +1,3 @@
-export var Red = "#F55";
-export var Green = "#5F5";
-export var Neutral = "#CCC";
+export var Red = "#C00";
+export var Green = "#0C0";
+export var Neutral = "#888";

--- a/webapp/src/DepIndicators.js
+++ b/webapp/src/DepIndicators.js
@@ -1,18 +1,44 @@
 import React, { PureComponent } from 'react';
 import { Red, Green, Neutral } from './Color';
 
-class DepIndicator extends PureComponent {
+export class DepIndicator extends PureComponent {
   render() {
+    var pie;
+    var radius = 1;
     var style = {
       fill: this.props.color,
       strokeWidth: 0,
     };
+    if (this.props.pie && this.props.pie.fraction) {
+      if (this.props.pie.fraction === 1) {
+        style.fill = this.props.pie.color;
+      } else {
+        var pieStyle= {
+          fill: this.props.pie.color,
+          stroke: this.props.pie.color,
+          strokeWidth: 0.02,
+        };
+        var largeArc = this.props.pie.fraction > 0.5 ? 1 : 0;
+        var angle = 2 * Math.PI * this.props.pie.fraction;
+        var x = this.props.cx + radius * Math.sin(angle);
+        var y = this.props.cy - radius * Math.cos(angle);
+        var pieD = [
+          `M ${this.props.cx} ${this.props.cy}`,
+          `L ${this.props.cx} ${this.props.cy - radius}`,
+          `A ${radius} ${radius} 0 ${largeArc} 1 ${x} ${y}`,
+          `Z`,
+        ];
+        pie = <path d={pieD.join(' ')} style={pieStyle}></path>
+      }
+    }
     return <g className="DepIndicator">
       <title>{this.props.title}</title>
-      <circle cx={this.props.cx} cy={this.props.cy} r="1" style={style}>
-          </circle>
+      <circle cx={this.props.cx} cy={this.props.cy} r={radius} style={style}>
+      </circle>
+      {pie}
       <text x={this.props.cx} y={this.props.cy}
-          textAnchor="middle" dominantBaseline="central">
+          textAnchor="middle" dominantBaseline="central"
+          style={{fontWeight: 'bold', fill: 'white'}}>
         {this.props.count}
       </text>
     </g>
@@ -21,11 +47,15 @@ class DepIndicator extends PureComponent {
 
 class DependenciesIndicator extends PureComponent {
   render() {
-    var count, color, title;
+    var count, color, title, pie;
     if (this.props.blockers) {
       count = this.props.blockers;
       color = Red;
       title = `${count} blockers (of ${this.props.dependencies} dependencies)`;
+      pie = {
+        color: Green,
+        fraction: 1 - count / this.props.dependencies,
+      };
     } else {
       count = this.props.dependencies;
       color = Green;
@@ -33,7 +63,7 @@ class DependenciesIndicator extends PureComponent {
     }
     return <DepIndicator
       title={title} cx={this.props.cx} cy={this.props.cy}
-      count={count} color={color} />
+      count={count} color={color} pie={pie} />
   }
 }
 

--- a/webapp/src/DepIndicators.test.js
+++ b/webapp/src/DepIndicators.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import DepIndicators from './DepIndicators';
+import { Red, Green } from './Color';
+import DepIndicators, { DepIndicator } from './DepIndicators';
 
 it('thick renders without crashing', () => {
   const svg = document.createElement('svg');
@@ -52,6 +53,19 @@ it('no dependents renders without crashing', () => {
       dependencies={5}
       related={1}
       done={false} />,
+    svg
+  );
+});
+
+it('full pie renders without crashing', () => {
+  const svg = document.createElement('svg');
+  ReactDOM.render(
+    <DepIndicator
+      cx={0} cy={0}
+      title="testing pie.fraction == 1"
+      count={3}
+      color={Red}
+      pie={{color: Green, fraction: 1}} />,
     svg
   );
 });


### PR DESCRIPTION
Also change the number to white, matching the mocks.  Bold the number and darken the other colors to make the white numbers more visible.

Fixes #12.