### PR TITLE
*: Granular react-router imports (from react-router/lib/${class})

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
-import { Router, IndexRoute, Route, hashHistory } from 'react-router'
+import Router from 'react-router/lib/Router';
+import IndexRoute from 'react-router/lib/IndexRoute';
+import Route from 'react-router/lib/Route';
+import hashHistory from 'react-router/lib/hashHistory';
 import './App.css';
 import DepGraph from './DepGraph';
 import GetDummyHostNodes, { CanonicalDummyHostKey } from './DummyHost';

--- a/webapp/src/App.test.js
+++ b/webapp/src/App.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { hashHistory } from 'react-router';
+import hashHistory from 'react-router/lib/hashHistory';
 import App, { DepGraphView } from './App';
 
 it('home page renders without crashing', () => {

--- a/webapp/src/Home.js
+++ b/webapp/src/Home.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Link } from 'react-router'
+import Link from 'react-router/lib/Link';
 import github from './logo/github.svg';
 import './Home.css';
 

--- a/webapp/src/Layout.js
+++ b/webapp/src/Layout.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router'
+import Link from 'react-router/lib/Link';
 import logo from './logo/depviz.svg';
 import Jump from './Jump';
 import './Layout.css';


### PR DESCRIPTION
As documented [here][1].  This only cuts ~10 kB from our compiled bundle (4042769 -> 4032506 bytes, so about 0.2%), but it's a straightforward enough change that I'll make it anyway ;).

What we really want to trim our bundle size down is [dynamic routing][2], so we can get a homepage up quickly and save the heavy graph deps for later (removing the DepGraph import from App.js gets the main JS bundle down to 296kB, over a 10x reduction from the current 4MB).  But I haven't had time to figure that out yet.

[1]: https://github.com/ReactTraining/react-router/blob/v3.0.0/docs/guides/MinimizingBundleSize.md
[2]: https://github.com/ReactTraining/react-router/blob/v3.0.0/docs/guides/DynamicRouting.md