### PR TITLE
DepCard: Clip long entries in the left column

### DIFF
--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -65,6 +65,16 @@ class DepCard extends PureComponent {
       expanded={this.props.expanded} />
   }
 
+  id(suffix) {
+    var name = this.props.slug
+      .replace(/^[^:A-Z_a-z]/g, '_')
+      .replace(/[^:A-Z_a-z-.0-9]+/g, '_');
+    if (suffix) {
+      name += suffix;
+    }
+    return name;
+  }
+
   render() {
     var width, height, comments, labels, people, tasks, title;
     var additionalIDTitle;
@@ -132,14 +142,37 @@ class DepCard extends PureComponent {
       `A ${radius} ${radius} 0 0 1 ${left} ${bottomCenter}`,
       `Z`,
     ];
+    var idClipPath;
+    if (this.props.expanded && this.props.people) {
+      idClipPath = 'url(#' + this.id('_left_column') + ')';
+    } else {
+      idClipPath = 'url(#' + this.id('_full_width') + ')';
+    }
+
     if (this.props.expanded) {
+      var titleClipPath;
+      if (this.props.comments) {
+        titleClipPath = 'url(#' + this.id('_left_column') + ')';
+      } else {
+        titleClipPath = 'url(#' + this.id('_full_width') + ')';
+      }
       title = <g>
         <title>{this.props.title}</title>
-        <text x={leftCenter} y={topCenter + imageHeight + lineSep}>
+        <text x={leftCenter} y={topCenter + imageHeight + lineSep}
+            clipPath={titleClipPath}>
           {this.props.title}
         </text>
       </g>
       if (this.props.labels) {
+        var labelsClipPath;
+        if (this.props.tasks) {
+          labelsClipPath = 'url(#' + this.id('_left_column') + ')';
+        } else {
+          labelsClipPath = 'url(#' + this.id('_full_width') + ')';
+        }
+        var labelTitle = this.props.labels.map(function (label) {
+          return label.name;
+        }).join('\n');
         // FIXME: wrap in boxes using getComputedTextLength
         labels = this.props.labels.map(function (label) {
           return <tspan key={label.name} style={{fill: label.color}}>
@@ -149,7 +182,8 @@ class DepCard extends PureComponent {
         for (var i = labels.length - 1; i > 0; i--) {
           labels.splice(i, 0, ' ');
         }
-        labels = <g>
+        labels = <g clipPath={labelsClipPath}>
+          <title>{labelTitle}</title>
           <text x={leftCenter} y={topCenter + imageHeight + 2 * lineSep}>
             {labels}
           </text>
@@ -189,6 +223,12 @@ class DepCard extends PureComponent {
       additionalIDTitle = '\n' + this.props.title;
     }
     return <g className="DepCard" xmlnsXlink="http://www.w3.org/1999/xlink">
+      <clipPath id={this.id('_full_width')}>
+        <rect x={left} y={top} width={width} height={height} />
+      </clipPath>
+      <clipPath id={this.id('_left_column')}>
+        <rect x={left} y={top} width={rightColumn - left} height={height} />
+      </clipPath>
       <rect
         x={left} y={top} width={width} height={height}
         rx={radius} ry={radius} style={backgroundStyle}>
@@ -210,8 +250,9 @@ class DepCard extends PureComponent {
           {this.props.slug}{additionalIDTitle}
         </title>
         <text
-          x={leftCenter + imageHeight + 0.4}
-          y={topCenter + 1}>
+            x={leftCenter + imageHeight + 0.4}
+            y={topCenter + 1}
+            clipPath={idClipPath}>
           {this.props.slug.replace(/^[^\/]*\//, '')}
         </text>
       </a>

--- a/webapp/src/DepCard.test.js
+++ b/webapp/src/DepCard.test.js
@@ -139,6 +139,29 @@ it('expanded with multiple labels renders without crashing', () => {
   );
 });
 
+it('expanded with no right column renders without crashing', () => {
+  const svg = document.createElement('svg');
+  const labels = [
+    {name: 'bug', 'color': '#ff0000'},
+    {name: 'help wanted', 'color': '#0000ff'},
+  ];
+  ReactDOM.render(
+    <DepCard
+      cx={40} cy={30}
+      host="github.com"
+      slug="github.com/jbenet/depviz#1"
+      title="depviz v0: single page rendering"
+      href="https://github.com/jbenet/depviz/issues/1"
+      dependencies={5}
+      related={1}
+      dependents={20}
+      done={false}
+      labels={labels}
+      expanded={true} />,
+    svg
+  );
+});
+
 it('blocker count with some completed dependencies', () => {
   var node = new DepCard({
     slug: 'test',


### PR DESCRIPTION
Expanded cards have three rows and potentially two columns.  Setup two `clipPath` rectangles per card, one for the left column and one for the whole card.  For each expandable line element starting in the left column, associate it with:

* the left-column clipPath if that line has a right-column entry (e.g. keep the ID to the left column if there is a person entry to its right).
* the full-width clipPath if that line does not have a right-column entry (e.g. allow the ID to use the full width if there is no person entry to its right).

The new ID method ensures a valid charset for our card IDs, since [SVG 1.1 punts to XML 1.0 for `id`][1], [XML 1.0 requires a Name][2], [Names have a NameStartChar and some number of NameChars][3], and [those][4] [Name*Chars][5] match my regexps (and also contain additional non-ASCII characters which I don't see a need to preserve yet).

SVG 1.1 [prefers to have referenced elements in a leading `<defs>` block for understandability and accessibility][6].  We don't do that here because it doesn't play nicely with the opaque-component approach that React prefers.

Also add a title to the label list, so folks can get the full list in a tooltip if the displayed list is clipped.

Entries in the right column and dep-indicators are usually short enough that they don't need clipping.  The exception to that might be people, but we can address that in later work.

Fixes #47.

[1]: https://www.w3.org/TR/SVG/struct.html#IDAttribute
[2]: https://www.w3.org/TR/2008/REC-xml-20081126/#id
[3]: https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Name
[4]: https://www.w3.org/TR/2008/REC-xml-20081126/#NT-NameStartChar
[5]: https://www.w3.org/TR/2008/REC-xml-20081126/#NT-NameChar
[6]: https://www.w3.org/TR/SVG/struct.html#DefsElement