### PR TITLE
Color: Rename Red -> Bad and Green -> Good

### DIFF
--- a/webapp/src/Color.js
+++ b/webapp/src/Color.js
@@ -1,3 +1,3 @@
-export var Red = "#C00";
-export var Green = "#0C0";
+export var Bad = "#C00";
+export var Good = "#0C0";
 export var Neutral = "#888";

--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import asana from './logo/asana.svg';
 import github from './logo/github.svg';
 import gitlab from './logo/gitlab.svg';
-import { Red, Green, Neutral } from './Color';
+import { Bad, Good, Neutral } from './Color';
 import DepIndicators from './DepIndicators';
 
 class DepCard extends PureComponent {
@@ -82,7 +82,7 @@ class DepCard extends PureComponent {
     var style = {
       fill: color,
       fillOpacity: 0.1,
-      stroke: this.props.done ? Green : Red,
+      stroke: this.props.done ? Good : Bad,
       strokeWidth: 0.2,
     };
     var backgroundStyle = {
@@ -90,7 +90,7 @@ class DepCard extends PureComponent {
       stroke: 'none',
     };
     var taskStyle = {
-      fill: Green,
+      fill: Good,
       fillOpacity: 0.1,
       stroke: 'none',
     };

--- a/webapp/src/DepGraph.js
+++ b/webapp/src/DepGraph.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Red, Green } from './Color';
+import { Bad, Good } from './Color';
 import Graph from './Graph';
 
 class DepGraph extends PureComponent {
@@ -117,7 +117,7 @@ class DepGraph extends PureComponent {
     var renderEdge = function(data) {
       var key = data.node1.props.slug + '-' + data.node2.props.slug;
       var style = {
-        stroke: data.node1.props.done ? Green : Red,
+        stroke: data.node1.props.done ? Good : Bad,
         strokeWidth: 0.2,
       };
       return <path key={key} d={data.path} style={style} />

--- a/webapp/src/DepIndicators.js
+++ b/webapp/src/DepIndicators.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Red, Green, Neutral } from './Color';
+import { Bad, Good, Neutral } from './Color';
 
 export class DepIndicator extends PureComponent {
   render() {
@@ -50,15 +50,15 @@ class DependenciesIndicator extends PureComponent {
     var count, color, title, pie;
     if (this.props.blockers) {
       count = this.props.blockers;
-      color = Red;
+      color = Bad;
       title = `${count} blockers (of ${this.props.dependencies} dependencies)`;
       pie = {
-        color: Green,
+        color: Good,
         fraction: 1 - count / this.props.dependencies,
       };
     } else {
       count = this.props.dependencies;
-      color = Green;
+      color = Good;
       title = `${this.props.dependencies} dependencies (no blockers)`;
     }
     return <DepIndicator
@@ -80,7 +80,7 @@ class DependentsIndicator extends PureComponent {
   render() {
     var color = Neutral;
     if (this.props.dependents) {
-      color = this.props.done ? Green : Red;
+      color = this.props.done ? Good : Bad;
     }
     return <DepIndicator
       title={`${this.props.dependents} dependent issues`}

--- a/webapp/src/DepIndicators.test.js
+++ b/webapp/src/DepIndicators.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Red, Green } from './Color';
+import { Bad, Good } from './Color';
 import DepIndicators, { DepIndicator } from './DepIndicators';
 
 it('thick renders without crashing', () => {
@@ -64,8 +64,8 @@ it('full pie renders without crashing', () => {
       cx={0} cy={0}
       title="testing pie.fraction == 1"
       count={3}
-      color={Red}
-      pie={{color: Green, fraction: 1}} />,
+      color={Bad}
+      pie={{color: Good, fraction: 1}} />,
     svg
   );
 });


### PR DESCRIPTION
The colors being used don't matter as much as the semantic meaning (bad = blocked, incomplete, etc.  good = unblocked, complete, etc.).  This sets us up for less intrusive palette changes in the future (e.g. for [color blindness][1] or to [match a logo][2]).

Generated with:

    $ sed -i 's/Red/Bad/g' $(git grep -l Red)
    $ sed -i 's/Green/Good/g' $(git grep -l Green)

[1]: https://github.com/jbenet/depviz/issues/49
[2]: https://github.com/jbenet/depviz/issues/14