### PR TITLE
WIP: Bookmarklet: Open depviz for the issue you're currently viewing

### DIFF
--- a/webapp/src/Bookmarklet.js
+++ b/webapp/src/Bookmarklet.js
@@ -1,0 +1,32 @@
+import React, { PureComponent } from 'react';
+
+class Bookmarklet extends PureComponent {
+  run() {
+    const depviz = 'https://jbenet.github.io/depviz/#/';
+    var protocol = location.protocol.replace(/:$/, '');
+    const host = location.href.split('://', 1)[0];
+    if (protocol !== 'https') {
+      alert(`the depviz bookmarklet does not currently support ${protocol}`);
+      return;
+    }
+    if (location.hostname !== 'github.com') {
+      alert(`the depviz bookmarklet does not currently support ${location.hostname}`);
+      return;
+    }
+    if (protocol === 'https') {
+      protocol = 'http';
+    }
+    const target = `${depviz}${protocol}/${location.hostname}${location.pathname}`;
+    location.assign(target);
+  };
+
+  render() {
+    var source = this.run.toString();
+    return <a href={`javascript:(function() {\n${source}\n run();})();`}>
+      {this.props.children}
+    </a>
+  }
+}
+
+export default Bookmarklet;
+

--- a/webapp/src/Home.js
+++ b/webapp/src/Home.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import Link from 'react-router/lib/Link';
+import Bookmarklet from './Bookmarklet';
 import github from './logo/github.svg';
 import './Home.css';
 
@@ -139,6 +140,17 @@ class Home extends PureComponent {
           </blockquote>
         </dd>
       </dl>
+
+      <h2 id="bookmarklet">Bookmarklet</h2>
+
+      <p>
+        This <Bookmarklet>depviz</Bookmarklet> bookmarklet takes you
+        to the depviz view of the issue you are currently viewing.  To
+        use it, copy the link into your bookmarks, and start browsing
+        a host supported by the <a href="#identifiers">jump bar</a>.
+        When you want to view the depviz graph for the issue you're
+        viewing, click on the bookmarklet.
+      </p>
 
       <h2 id="development">Development</h2>
 


### PR DESCRIPTION
This still needs test coverage for `run()`.

I'd like to have "The depviz bookmarklet" as the link text (and not just "depviz"), but both Chromium and Firefox use the link text as the default bookmark name.  By using only "depviz", we get a sane bookmark name without the user having to edit anything when creating the bookmark.

This is made tricky by GitHub's Content Security Policy, which [doesn't][1] [play][2] [nicely][3] [with][4] all browsers.  Despite the [open Chromium issue][3], the bookmarklet does work for me with Chromium 54.0.  And as expected from the [open Firefox issue][2], the bookmarklet does not work for me on Firefox 45.4.

[1]: https://github.com/blog/1477-content-security-policy#bookmarklets
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=866522
[3]: https://bugs.chromium.org/p/chromium/issues/detail?id=233903
[4]: https://www.w3.org/Bugs/Public/show_bug.cgi?id=23357