### PR TITLE
DepCard: Use wider strokes for border nodes

### DIFF
--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -95,6 +95,9 @@ class DepCard extends PureComponent {
       stroke: this.props.done ? Good : Bad,
       strokeWidth: 0.2,
     };
+    if (!this.props.done && !this.props.blockers) {
+      style.strokeWidth *= 2;
+    }
     var backgroundStyle = {
       fill: 'white',
       stroke: 'none',


### PR DESCRIPTION
The open issues without blockers are actionable.  Draw extra attention to them to make it easier to identify productive targets.

![border](https://cloud.githubusercontent.com/assets/209920/20960759/cd58b4ce-bc16-11e6-9294-3235b40ef258.png)
