### PR TITLE
README: Deduplicate "dependency visualizer for the web"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # depviz - dependency visualizer for the web
 
-> Dependency visualizer for the web https://jbenet.github.io/depviz
+> https://jbenet.github.io/depviz
 
 depviz started as [this discussion](https://github.com/jbenet/random-ideas/issues/37) -- see that thread for details. For now, this repo is only mockups.
 


### PR DESCRIPTION
This is already in the page header.  I [asked][1] for this deduping in #55, so the duplication may be intentional.  But I don't see a use for it.

[1]: https://github.com/jbenet/depviz/pull/55#discussion_r90928037