### PR TITLE
DepIndicators: Click on DependenciesIndicator to load dependencies

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -40,7 +40,10 @@ export class DepGraphView extends Component {
   }
 
   getNodes(key, pushNodes) {
-    return GetNodes(key, pushNodes, {expanded: this.expanded()});
+    return GetNodes(key, pushNodes, {
+      expanded: this.expanded(),
+      getNodes: this.getNodes.bind(this),
+    });
   }
 
   handleKeyPress(event) {

--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -44,7 +44,7 @@ class DepCard extends PureComponent {
     return count;
   }
 
-  depCard(cx, cy, nodes) {
+  depCard(cx, cy, nodes, pushNodes) {
     return <DepCard
       key={this.props.slug}
       cx={cx} cy={cy}
@@ -52,6 +52,7 @@ class DepCard extends PureComponent {
       host={this.props.host}
       title={this.props.title}
       href={this.props.href}
+      parents={this.parents()}
       blockers={this.blockerCount(nodes || {})}
       dependencies={this.dependencyCount()}
       related={this.relatedCount()}
@@ -62,7 +63,9 @@ class DepCard extends PureComponent {
       tasksCompleted={this.props.tasksCompleted}
       labels={this.props.labels}
       people={this.props.people}
-      expanded={this.props.expanded} />
+      expanded={this.props.expanded}
+      getNodes={this.props.getNodes}
+      pushNodes={pushNodes} />
   }
 
   id(suffix) {
@@ -225,6 +228,7 @@ class DepCard extends PureComponent {
     } else { /* collapsed */
       additionalIDTitle = '\n' + this.props.title;
     }
+    var unwalkedDependencies = this.props.done && this.props.parents.length;
     return <g className="DepCard" xmlnsXlink="http://www.w3.org/1999/xlink">
       <clipPath id={this.id('_full_width')}>
         <rect x={left} y={top} width={width} height={height} />
@@ -266,11 +270,14 @@ class DepCard extends PureComponent {
       {tasks}
       <DepIndicators
         cx={right} cy={this.props.cy} dy={height/2}
+        parents={this.props.parents}
         blockers={this.props.blockers}
         dependencies={this.props.dependencies}
         related={this.props.related}
         dependents={this.props.dependents}
-        done={this.props.done} />
+        done={this.props.done}
+        getNodes={unwalkedDependencies ? this.props.getNodes : undefined}
+        pushNodes={unwalkedDependencies ? this.props.pushNodes : undefined} />
     </g>
   }
 }

--- a/webapp/src/DepGraph.js
+++ b/webapp/src/DepGraph.js
@@ -112,7 +112,8 @@ class DepGraph extends PureComponent {
   render() {
     var _this = this;
     var renderNode = function(data) {
-      return data.node.depCard(data.cx, data.cy, _this.state.nodes);
+      return data.node.depCard(
+        data.cx, data.cy, _this.state.nodes, _this.pushNodes.bind(_this));
     }
     var renderEdge = function(data) {
       var key = data.node1.props.slug + '-' + data.node2.props.slug;

--- a/webapp/src/DepIndicators.js
+++ b/webapp/src/DepIndicators.js
@@ -5,13 +5,17 @@ export class DepIndicator extends PureComponent {
   render() {
     var pie;
     var radius = 1;
-    var style = {
+    var circleStyle = {
       fill: this.props.color,
       strokeWidth: 0,
     };
+    var groupStyle = {};
+    if (this.props.onClick) {
+      groupStyle.cursor = 'pointer';
+    }
     if (this.props.pie && this.props.pie.fraction) {
       if (this.props.pie.fraction === 1) {
-        style.fill = this.props.pie.color;
+        circleStyle.fill = this.props.pie.color;
       } else {
         var pieStyle= {
           fill: this.props.pie.color,
@@ -31,9 +35,11 @@ export class DepIndicator extends PureComponent {
         pie = <path d={pieD.join(' ')} style={pieStyle}></path>
       }
     }
-    return <g className="DepIndicator">
+    return <g className="DepIndicator"
+        style={groupStyle} onClick={this.props.onClick}>
       <title>{this.props.title}</title>
-      <circle cx={this.props.cx} cy={this.props.cy} r={radius} style={style}>
+      <circle
+        cx={this.props.cx} cy={this.props.cy} r={radius} style={circleStyle}>
       </circle>
       {pie}
       <text x={this.props.cx} y={this.props.cy}
@@ -45,9 +51,17 @@ export class DepIndicator extends PureComponent {
   }
 }
 
-class DependenciesIndicator extends PureComponent {
+export class DependenciesIndicator extends PureComponent {
+  getDependencies() {
+    for (var index in this.props.parents) {
+      if (Object.prototype.hasOwnProperty.call(this.props.parents, index)) {
+        this.props.getNodes(this.props.parents[index], this.props.pushNodes);
+      }
+    }
+  }
+
   render() {
-    var count, color, title, pie;
+    var count, color, title, pie, onClick;
     if (this.props.blockers) {
       count = this.props.blockers;
       color = Bad;
@@ -60,10 +74,13 @@ class DependenciesIndicator extends PureComponent {
       count = this.props.dependencies;
       color = Good;
       title = `${this.props.dependencies} dependencies (no blockers)`;
+      if (this.props.getNodes && this.props.pushNodes) {
+        onClick = this.getDependencies.bind(this);
+      }
     }
     return <DepIndicator
       title={title} cx={this.props.cx} cy={this.props.cy}
-      count={count} color={color} pie={pie} />
+      count={count} color={color} pie={pie} onClick={onClick} />
   }
 }
 
@@ -98,8 +115,11 @@ class DepIndicators extends PureComponent {
     return <g className="DepIndicators">
       <DependenciesIndicator
         cx={this.props.cx} cy={this.props.cy - this.props.dy}
+        parents={this.props.parents}
         blockers={this.props.blockers}
-        dependencies={this.props.dependencies} />
+        dependencies={this.props.dependencies}
+        getNodes={this.props.getNodes}
+        pushNodes={this.props.pushNodes} />
       <DependentsIndicator
         cx={this.props.cx} cy={this.props.cy + this.props.dy}
         dependents={this.props.dependents}

--- a/webapp/src/DepIndicators.test.js
+++ b/webapp/src/DepIndicators.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Bad, Good } from './Color';
-import DepIndicators, { DepIndicator } from './DepIndicators';
+import DepIndicators, { DependenciesIndicator, DepIndicator } from './DepIndicators';
 
 it('thick renders without crashing', () => {
   const svg = document.createElement('svg');
@@ -67,5 +67,31 @@ it('full pie renders without crashing', () => {
       color={Bad}
       pie={{color: Good, fraction: 1}} />,
     svg
+  );
+});
+
+it('dependencies walked without crashing', () => {
+  const svg = document.createElement('svg');
+  var nodes = [];
+  var getNodes = function(key, pushNodes) {
+    pushNodes([key]);
+  };
+  var pushNodes = function(nds) {
+    nodes = nodes.concat(nds);
+  };
+  ReactDOM.render(
+    <DependenciesIndicator
+      cx={0} cy={0}
+      title="testing pie.fraction == 1"
+      parents={['parent1', 'parent2']}
+      blockers={0}
+      dependencies={2}
+      getNodes={getNodes}
+      pushNodes={pushNodes} />,
+    svg ,
+    function () {
+      this.getDependencies();
+      expect(nodes).toEqual(['parent1', 'parent2']);
+    }
   );
 });


### PR DESCRIPTION
We currently don't walk dependencies for closed issues, because they're not related to future progress.  However, the completed-issue graph is useful for historical context, and @jbenet is [interested in walking that graph][1].

To make this straightforward, we probably want a way to configure a hop-depth from a current node.  But the current UI lacks a “current node” concept and we haven't settled on a UI for selecting nodes (#30, #45).  In the meantime, this patch gives users a way for users to drill down into the dependencies of any closed issue by clicking on its dependencies indicator.

`unwalkedDependencies` is currently a bit sloppy, since it should be false if all of the parents have already been walked.  The current implementation is good enough for a first pass though.

[1]: https://github.com/jbenet/depviz/issues/13#issuecomment-262672545