### PR TITLE
*: Fix 'for ... in' guards

### DIFF
--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -16,8 +16,9 @@ class DepCard extends PureComponent {
 
   blockerCount(nodes) {
     var count = 0;
-    for (var index in (this.props.dependencies || [])) {
-      if (true) {
+    var dependencies = this.props.dependencies || [];
+    for (var index in dependencies) {
+      if (Object.prototype.hasOwnProperty.call(dependencies, index)) {
         var key = this.props.dependencies[index];
         if (nodes[key] !== undefined &&
             !nodes[key].props.done) {
@@ -35,7 +36,7 @@ class DepCard extends PureComponent {
   dependentCount(nodes) {
     var count = 0;
     for (var dependentKey in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, dependentKey)) {
         if (nodes[dependentKey].parents().indexOf(this.props.slug) !== -1) {
           count += 1;
         }

--- a/webapp/src/DepGraph.js
+++ b/webapp/src/DepGraph.js
@@ -18,7 +18,7 @@ class DepGraph extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (nextProps.slugs !== this.props.slugs) {
       for (var index in nextProps.slugs) {
-        if (true) {
+        if (Object.prototype.hasOwnProperty.call(nextProps.slugs, index)) {
           var key = nextProps.slugs[index];
           key = this.props.canonicalKey(key);
           if (!this.state.nodes[key]) {
@@ -45,7 +45,7 @@ class DepGraph extends PureComponent {
       throw new Error('canonicalKey unset');
     }
     for (var index in this.props.slugs) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(this.props.slugs, index)) {
         var key = this.props.slugs[index];
         this.getNodes(key);
       }
@@ -59,7 +59,7 @@ class DepGraph extends PureComponent {
       var stateNodes = {...prevState.nodes};
       var pending = {...prevState.pending};
       for (index in nodes) {
-        if (true) {
+        if (Object.prototype.hasOwnProperty.call(nodes, index)) {
           var node = nodes[index];
           stateNodes[node.props.slug] = node;
           delete pending[node.props.slug];
@@ -68,12 +68,12 @@ class DepGraph extends PureComponent {
       return {...prevState, nodes: stateNodes, pending: pending};
     });
     for (index in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, index)) {
         node = nodes[index];
         if (!node.props.done) {
           var parents = node.parents();
           for (var i in parents) {
-            if (true) {
+            if (Object.prototype.hasOwnProperty.call(parents, i)) {
               var relatedKey = parents[i];
               this.getNodes(relatedKey);
             }

--- a/webapp/src/DummyHost.test.js
+++ b/webapp/src/DummyHost.test.js
@@ -31,7 +31,7 @@ it('dummy key fetches without crashing', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -43,7 +43,7 @@ it('repo key fetches without crashing', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -55,7 +55,7 @@ it('user key fetches without crashing', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }

--- a/webapp/src/GitHub.test.js
+++ b/webapp/src/GitHub.test.js
@@ -53,7 +53,7 @@ it('foo/#3 reference is skipped without crashing', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -73,7 +73,7 @@ it('long and short references are understood', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -95,7 +95,7 @@ it('tasks are counted', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -116,7 +116,7 @@ it('repository keys are understood', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }
@@ -135,7 +135,7 @@ it('user keys are understood', () => {
   var nodes = [];
   function pushNodes(newNodes) {
     for (var index in newNodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
         nodes.push(newNodes[index]);
       }
     }

--- a/webapp/src/Graph.js
+++ b/webapp/src/Graph.js
@@ -19,19 +19,19 @@ class Graph extends PureComponent {
     ];
     var key, name, node;
     for (key in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, key)) {
         node = nodes[key];
         name = this.nodeName(key);
         gv.push('  node [href=' + name + '] ' + name + ';');
       }
     }
     for (key in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, key)) {
         node = nodes[key];
         name = this.nodeName(key);
         var parents = node.parents();
         for (var index in parents) {
-          if (true) {
+          if (Object.prototype.hasOwnProperty.call(parents, index)) {
             var parent = parents[index];
             var parentName = this.nodeName(parent);
             gv.push('  edge [href=' + this.edgeName(parent, key) + '] ' + parentName + ' -> ' + name + ';');
@@ -92,11 +92,11 @@ class Graph extends PureComponent {
     ));
     var positioned = [];
     for (var key in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, key)) {
         node = nodes[key];
         name = this.nodeName(key);
         for (index1 in json.svg.g[0].g) {
-          if (true) {
+          if (Object.prototype.hasOwnProperty.call(json.svg.g[0].g, index1)) {
             g = json.svg.g[0].g[index1];
             if (g.title[0] === name) {
               var text = g.g[0].a[0].text[0].$;
@@ -117,16 +117,16 @@ class Graph extends PureComponent {
     }
     var edges = [];
     for (var k2 in nodes) {
-      if (true) {
+      if (Object.prototype.hasOwnProperty.call(nodes, k2)) {
         node2 = nodes[k2];
         var parents = node2.parents();
         for (index1 in parents) {
-          if (true) {
+          if (Object.prototype.hasOwnProperty.call(parents, index1)) {
             var k1 = parents[index1];
             name = this.edgeName(k1, k2);
             node1 = nodes[k1];
             for (index2 in json.svg.g[0].g) {
-              if (true) {
+              if (Object.prototype.hasOwnProperty.call(json.svg.g[0].g, index2)) {
                 g = json.svg.g[0].g[index2];
                 if (g.title[0] === name.replace('__to__', '->')) {
                   // FIXME: parse from g.g[0].a[0].path[0].$.d and

--- a/webapp/src/Layout.css
+++ b/webapp/src/Layout.css
@@ -1,7 +1,7 @@
 .Layout-header {
   background-color: #222;
   color: white;
-	padding: 2px; /* sync with HeaderHeight */
+  padding: 2px; /* sync with HeaderHeight */
 }
 
 .Layout-logo {

--- a/webapp/src/Layout.test.js
+++ b/webapp/src/Layout.test.js
@@ -18,11 +18,11 @@ it('generated expected jump sizes', () => {
     <Layout router={router} />,
     div,
     function () {
-			expect(this.getJumpSize(600)).toBe(40);
-			expect(this.getJumpSize(500)).toBe(40);
+      expect(this.getJumpSize(600)).toBe(40);
+      expect(this.getJumpSize(500)).toBe(40);
       expect(this.getJumpSize(400)).toBe(27);
-			expect(this.getJumpSize(300)).toBe(15);
-			expect(this.getJumpSize(200)).toBe(15);
+      expect(this.getJumpSize(300)).toBe(15);
+      expect(this.getJumpSize(200)).toBe(15);
     }
   );
 });


### PR DESCRIPTION
I'd been adding the `if (true)` “guards” because I didn't understand the ESLint warning.  After reading [the][1] [docs][2], I see that the rule is intended to protect from iterating over keys defined in prototypes. This commit uses the recommended approach from [here][2] to ensure we only iterate over directly-defined keys.

[1]: http://eslint.org/docs/rules/guard-for-in
[2]: https://javascriptweblog.wordpress.com/2011/01/04/exploring-javascript-for-in-loops/