### PR TITLE
Config: Add a configuration page

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -4,6 +4,7 @@ import IndexRoute from 'react-router/lib/IndexRoute';
 import Route from 'react-router/lib/Route';
 import hashHistory from 'react-router/lib/hashHistory';
 import './App.css';
+import Config from './Config';
 import DepGraph from './DepGraph';
 import GetDummyHostNodes, { CanonicalDummyHostKey } from './DummyHost';
 import GetGitHubNodes, { CanonicalGitHubKey } from './GitHub';
@@ -25,9 +26,22 @@ function getSize() {
   }
 }
 
+function changeView(prevState, nextState, replace) {
+  if (prevState.location.pathname === '/config' &&
+      nextState.location.pathname !== '/config' &&
+      nextState.location.query.back) {
+    var query = Object.assign({}, nextState.location.query);
+    delete query.back;
+    replace({
+      pathname: nextState.location.pathname,
+      query: query,
+    });
+  }
+}
+
 export class HomeView extends Component {
   render() {
-    return <Home getSize={getSize} />
+    return <Home getSize={getSize} location={this.props.location} />
   }
 }
 
@@ -44,15 +58,18 @@ export class DepGraphView extends Component {
   }
 
   handleKeyPress(event) {
+    var query = Object.assign({}, this.props.location.query);
     if (event.key === 'e' && !this.expanded()) {
+      query.expanded = 'true';
       this.props.router.replace({
         pathname: this.props.location.pathname,
-        query: {expanded: 'true'},
+        query: query,
       });
     } else if (event.key === 'c' && this.expanded()) {
+      delete query.expanded;
       this.props.router.replace({
         pathname: this.props.location.pathname,
-        query: null,
+        query: query,
       });
     }
   }
@@ -73,7 +90,10 @@ function enterGraphView(nextState, replace) {
   if (splat === canonicalKey || splat === canonicalPath) {
     return;
   }
-  replace('/http/' + canonicalPath);
+  replace({
+    pathname: '/http/' + canonicalPath,
+    query: nextState.location.query,
+  });
 }
 
 class App extends Component {
@@ -81,8 +101,9 @@ class App extends Component {
     return (
       <div className="App">
         <Router history={hashHistory}>
-          <Route path="/" component={Layout}>
+          <Route path="/" component={Layout} onChange={changeView}>
             <IndexRoute component={HomeView} />
+            <Route path="/config" component={Config} />
             <Route path="/http/*" component={DepGraphView}
               onEnter={enterGraphView} />
           </Route>

--- a/webapp/src/App.test.js
+++ b/webapp/src/App.test.js
@@ -8,11 +8,24 @@ it('home page renders without crashing', () => {
   ReactDOM.render(<App />, div);
 });
 
-it('issue view renders without crashing', () => {
+it('leaving the config view clears ?back=...', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-    <DepGraphView params={{splat: 'dummy/jbenet/depviz/30'}} />,
-    div
+    <App />,
+    div,
+    function () {
+      hashHistory.push({
+        pathname: '/config',
+        query: {back: '/http/dummy/jbenet'},
+      });
+      hashHistory.push({
+        pathname: '/',
+        query: {back: '/http/dummy/jbenet'},
+      });
+      expect(
+        hashHistory.getCurrentLocation().query
+      ).toEqual({});
+    },
   );
 });
 
@@ -72,7 +85,7 @@ it('expand/collapse key presses render without crashing', () => {
       this.handleKeyPress({key: 'e'});
       expect(location.query.expanded).toBe('true');
       this.handleKeyPress({key: 'c'});
-      expect(location.query).toBe(null);
+      expect(location.query).toEqual({});
     },
   );
 });

--- a/webapp/src/Config.css
+++ b/webapp/src/Config.css
@@ -1,0 +1,4 @@
+.Config {
+  padding-left: 10px;
+  padding-right: 10px;
+}

--- a/webapp/src/Config.js
+++ b/webapp/src/Config.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from 'react';
+import './Config.css';
+
+class Config extends PureComponent {
+  expanded() {
+    return (
+      this.props.location &&
+      this.props.location.query.expanded === 'true'
+    );
+  }
+
+  handleExpanded(event) {
+    var query = Object.assign({}, this.props.location.query);
+    if (event.target.checked) {
+      query.expanded = 'true';
+    } else {
+      delete query.expanded;
+    }
+    this.props.router.replace({
+      pathname: this.props.location.pathname,
+      query: query,
+    });
+  }
+
+  render() {
+    return <div className="Config">
+      <h2 id="config">Configuration</h2>
+
+      <form>
+        <p>
+          <label>
+            Expanded cards:&nbsp;
+            <input
+              name="expanded" type="checkbox"
+              checked={this.expanded()}
+              onChange={this.handleExpanded.bind(this)} />
+          </label>
+        </p>
+      </form>
+    </div>
+  }
+}
+
+export default Config;

--- a/webapp/src/Config.test.js
+++ b/webapp/src/Config.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Config from './Config';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  var router = jest.fn();
+  ReactDOM.render(
+    <Config router={router} location={{pathname: '/config', query: {}}} />,
+    div
+  );
+});
+
+it('handles expanded check', () => {
+  const div = document.createElement('div');
+  var router = {replace: jest.fn()};
+  ReactDOM.render(
+    <Config router={router} location={{pathname: '/config', query: {}}} />,
+    div,
+    function() {
+      this.handleExpanded({target: {checked: true}});
+      expect(router.replace).toHaveBeenCalledTimes(1);
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/config',
+        query: {expanded: 'true'},
+      });
+    }
+  );
+});
+
+it('handles expanded uncheck', () => {
+  const div = document.createElement('div');
+  var router = {replace: jest.fn()};
+  ReactDOM.render(
+    <Config
+      router={router}
+      location={{pathname: '/config', query: {expanded: 'true'}}} />,
+    div,
+    function() {
+      this.handleExpanded({target: {checked: false}});
+      expect(router.replace).toHaveBeenCalledTimes(1);
+      expect(router.replace).toHaveBeenCalledWith({
+        pathname: '/config',
+        query: {},
+      });
+    }
+  );
+});

--- a/webapp/src/Home.js
+++ b/webapp/src/Home.js
@@ -60,7 +60,7 @@ class Home extends PureComponent {
           <p>
             Listing all the open issues assigned to that user and
             their open dependencies.  For example,&nbsp;
-            <Link to="http/github.com/jbenet">
+            <Link to={{pathname: 'http/github.com/jbenet', query: this.props.location.query}}>
               <code>github.com/jbenet</code>
             </Link>.
           </p>
@@ -74,7 +74,7 @@ class Home extends PureComponent {
           <p>
             Listing all the open issues in that repository and their
             open dependencies.  For example,&nbsp;
-            <Link to="http/github.com/jbenet/depviz">
+            <Link to={{pathname: 'http/github.com/jbenet/depviz', query: this.props.location.query}}>
               <code>github.com/jbenet/depviz</code>
             </Link>.
           </p>
@@ -103,7 +103,7 @@ class Home extends PureComponent {
           <p>
             Listing the referenced issue and all of its open
             dependencies.  For example,&nbsp;
-            <Link to="http/github.com/jbenet/depviz/1">
+            <Link to={{pathname: 'http/github.com/jbenet/depviz/1', query: this.props.location.query}}>
               <code>github.com/jbenet/depviz#1</code>
             </Link>.
           </p>

--- a/webapp/src/Home.test.js
+++ b/webapp/src/Home.test.js
@@ -4,5 +4,5 @@ import Home from './Home';
 
 it('home page without size renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<Home />, div);
+  ReactDOM.render(<Home location={{query: {}}}/>, div);
 });

--- a/webapp/src/Layout.css
+++ b/webapp/src/Layout.css
@@ -7,3 +7,10 @@
 .Layout-logo {
   height: 36px; /* sync with HeaderHeight */
 }
+
+.Layout-header-icon {
+  float: right;
+  font-size: 30px;
+  color: white;
+  text-decoration: none;
+}

--- a/webapp/src/Layout.js
+++ b/webapp/src/Layout.js
@@ -12,8 +12,8 @@ class Layout extends Component {
     width = width === undefined ? window.innerWidth : width;
     const max = 40; /* number of chars we'd like if we have space */
     const min = 15; /* number of chars we require even if it will reflow */
-    const maxCutoff = 500; /* width above which Jump is max */
-    const minCutoff = 300; /* width below which Jump is min */
+    const maxCutoff = 530; /* width above which Jump is max */
+    const minCutoff = 330; /* width below which Jump is min */
     if (width >= maxCutoff) {
       return max;
     } else if (width <= minCutoff) {
@@ -24,13 +24,43 @@ class Layout extends Component {
     ));
   }
 
+  jump(pathname) {
+    this.props.router.push({
+      pathname: pathname,
+      query: this.props.location.query,
+    });
+  }
+
   render() {
+    var settingsLink, settingsStyle;
+    if (this.props.location.pathname === '/config') {
+      settingsStyle = {
+        color: 'orange',
+      };
+      var query = Object.assign({}, this.props.location.query);
+      var back = query.back || '/';
+      delete query.back;
+      settingsLink = {
+        pathname: back,
+        query: query,
+      };
+    } else {
+      settingsLink = {
+        pathname: '/config',
+        query: Object.assign({
+          back: this.props.location.pathname,
+        }, this.props.location.query),
+      };
+    }
     return <div className="Layout">
       <div className="Layout-header">
-        <Link to="/">
+        <Link to={{pathname: '/', query: this.props.location.query}}>
           <img src={logo} className="Layout-logo" alt="logo (homepage)" />
         </Link>
-        <Jump push={this.props.router.push}
+        <Link className="Layout-header-icon" to={settingsLink} style={settingsStyle}>
+          ⚙
+        </Link>
+        <Jump push={this.jump.bind(this)}
           getSize={this.getJumpSize.bind(this)} />
       </div>
       {this.props.children}

--- a/webapp/src/Layout.test.js
+++ b/webapp/src/Layout.test.js
@@ -6,23 +6,40 @@ it('renders without crashing', () => {
   const div = document.createElement('div');
   var router = jest.fn();
   ReactDOM.render(
-    <Layout router={router} />,
+    <Layout router={router} location={{pathname: '/', query: {}}} />,
     div
   );
 });
 
-it('generated expected jump sizes', () => {
+it('preserves query parameters through jumps', () => {
+  const div = document.createElement('div');
+  var router = {push: jest.fn()};
+  ReactDOM.render(
+    <Layout router={router} location={{pathname: '/', query: {foo: 'bar'}}} />,
+    div,
+    function () {
+      this.jump('/config');
+      expect(router.push).toHaveBeenCalledTimes(1);
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/config',
+        query: {foo: 'bar'},
+      });
+    },
+  );
+});
+
+it('generates expected jump sizes', () => {
   const div = document.createElement('div');
   var router = jest.fn();
   ReactDOM.render(
-    <Layout router={router} />,
+    <Layout router={router} location={{pathname: '/', query: {}}} />,
     div,
     function () {
-			expect(this.getJumpSize(600)).toBe(40);
-			expect(this.getJumpSize(500)).toBe(40);
-      expect(this.getJumpSize(400)).toBe(27);
-			expect(this.getJumpSize(300)).toBe(15);
-			expect(this.getJumpSize(200)).toBe(15);
+      expect(this.getJumpSize(630)).toBe(40);
+      expect(this.getJumpSize(530)).toBe(40);
+      expect(this.getJumpSize(430)).toBe(27);
+      expect(this.getJumpSize(330)).toBe(15);
+      expect(this.getJumpSize(230)).toBe(15);
     }
   );
 });


### PR DESCRIPTION
We're storing app state in query parameters, which means we need to preserve those query parameters across links.  The form currently only allows users to toggle expanded-ness, which was already available via keybindings.  But the new UI is more usable via touch, and it sets the stage for more complicated configuration (e.g. setting GitHub credentials).

The `?back=…` handling lets users keep their place as they toggle in and out of the config view.  When you leave the config view by toggling the config link, we use the back parameter to send you back to the view you came from.  When you leave the config view via another link (e.g. the depviz icon or the jump bar), we need to clear the back
parameter.  We handle the clearing in changeView, bound to the `/`-wide onChange.  I couldn't find any hooks more tightly bound to the config view, because:

* [`componentWillUnmount`][1] is called before the location changes (so we can't clear back because we might still need it).
* [`onLeave`][2] does not provide access to either the next state or the replace function.

The config form uses [controlled components][3].

The config icon is U+2699 (GEAR).

This commit uses [`Object.assign`][4] frequently for copying objects so we can edit the copy without changing the original.  The method is in ECMAScript 2015 (6th Edition, ECMA-262) and is [supported on all major browsers except Internet Explorer][4].  If anybody complains about missing support, we can always add the polyfill (assuming react-scripts / babel don't already do that for us).

Fixes #34.

[1]: https://facebook.github.io/react/docs/react-component.html#componentwillunmount
[2]: https://github.com/ReactTraining/react-router/blob/v3.0.0/docs/API.md#onleaveprevstate
[3]: https://facebook.github.io/react/docs/forms.html
[4]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign