### PR TITLE
DepCard: Display status icon (e.g. for continuous integration tests)

### DIFF
--- a/webapp/__mocks__/github-api.js
+++ b/webapp/__mocks__/github-api.js
@@ -3,6 +3,10 @@ class GitHub {
     return new Issues(user, repo);
   }
 
+  getRepo(user, repo) {
+    return new Repository(user, repo);
+  }
+
   search() {
     return new Search();
   }
@@ -58,8 +62,9 @@ class Issues {
       body: bodyLines.join('\n') + '\n',
       html_url: `https://github.com/${this._user}/${this._repo}/issues/${number}`,
       number: number,
+      pull_request: number === 1 || number === 99 ? {} : null,
       repository_url: `https://api.github.com/repos/${this._user}/${this._repo}`,
-      state: number < 10 ? 'open' : 'closed',
+      state: number < 10 || number === 99 ? 'open' : 'closed',
       title: 'Some title for ' + number,
       comments: number % 2 ? 0 : number,
       labels: number % 2 ? [] : [
@@ -90,6 +95,22 @@ class Issues {
         this._getIssue(2),
       ]
     });
+  }
+}
+
+class Repository {
+  constructor(user, repo) {
+    this._user = user;
+    this._repo = repo;
+    this._calls = {};
+  }
+
+  _request(method, path, data, cb) {
+    if (path === '/repos/undefined/commits/refs/pull/99/head/status') {
+      cb(new Error(`error making request ${method} ${path}`));
+    } else {
+      cb(null, {state: 'success'});
+    }
   }
 }
 

--- a/webapp/src/DepCard.js
+++ b/webapp/src/DepCard.js
@@ -59,6 +59,7 @@ class DepCard extends PureComponent {
       related={this.relatedCount()}
       dependents={this.dependentCount(nodes || {})}
       done={this.props.done}
+      status={this.props.status}
       comments={this.props.comments}
       tasks={this.props.tasks}
       tasksCompleted={this.props.tasksCompleted}
@@ -80,14 +81,15 @@ class DepCard extends PureComponent {
   }
 
   render() {
-    var width, height, comments, labels, people, tasks, title;
+    var width, height, comments, labels, people, status, tasks, title;
     var additionalIDTitle;
     var imageHeight = 1.5;
-    var lineSep = 1.2;
+    var lineSpace = 0.3;
+    var lineSep = 1 + lineSpace;
     var radius = 0.5;
     if (this.props.expanded) {
       width = 24;
-      height = imageHeight + 2 * lineSep + 2 * radius;
+      height = 2 * (imageHeight + lineSpace) + 2 * lineSep + 2 * radius;
     } else {
       width = 15;
       height = Math.max(imageHeight + 2 * radius, 3);
@@ -134,7 +136,6 @@ class DepCard extends PureComponent {
     var right = this.props.cx + width/2;
     var leftCenter = left + radius;
     var rightCenter = right - radius;
-    var rightColumn = rightCenter - 4;
     var rightTask = left + width * taskRatio;
     var top = this.props.cy - height/2;
     var bottom = this.props.cy + height/2;
@@ -149,34 +150,16 @@ class DepCard extends PureComponent {
       `A ${radius} ${radius} 0 0 1 ${left} ${bottomCenter}`,
       `Z`,
     ];
-    var idClipPath;
-    if (this.props.expanded && this.props.people) {
-      idClipPath = 'url(#' + this.id('_left_column') + ')';
-    } else {
-      idClipPath = 'url(#' + this.id('_full_width') + ')';
-    }
-
+    var fullWidthClipPath = 'url(#' + this.id('_full_width') + ')';
     if (this.props.expanded) {
-      var titleClipPath;
-      if (this.props.comments) {
-        titleClipPath = 'url(#' + this.id('_left_column') + ')';
-      } else {
-        titleClipPath = 'url(#' + this.id('_full_width') + ')';
-      }
       title = <g>
         <title>{this.props.title}</title>
         <text x={leftCenter} y={topCenter + imageHeight + lineSep}
-            clipPath={titleClipPath}>
+            clipPath={fullWidthClipPath}>
           {this.props.title}
         </text>
       </g>
       if (this.props.labels) {
-        var labelsClipPath;
-        if (this.props.tasks) {
-          labelsClipPath = 'url(#' + this.id('_left_column') + ')';
-        } else {
-          labelsClipPath = 'url(#' + this.id('_full_width') + ')';
-        }
         var labelTitle = this.props.labels.map(function (label) {
           return label.name;
         }).join('\n');
@@ -189,7 +172,7 @@ class DepCard extends PureComponent {
         for (var i = labels.length - 1; i > 0; i--) {
           labels.splice(i, 0, ' ');
         }
-        labels = <g clipPath={labelsClipPath}>
+        labels = <g clipPath={fullWidthClipPath}>
           <title>{labelTitle}</title>
           <text x={leftCenter} y={topCenter + imageHeight + 2 * lineSep}>
             {labels}
@@ -197,33 +180,59 @@ class DepCard extends PureComponent {
         </g>
       }
       if (this.props.people) {
-        people = this.props.people.slice(0, 1).map(function (person) {
+        var imageClipPath = this.id('_images');
+        var unclippedPeople = this.props.people.map(function (person, index) {
           var image;
+          var imageX = leftCenter + index * imageHeight;
           if (person.avatar) {
             image = <image
-              x={rightColumn} y={topCenter}
+              x={imageX} y={bottomCenter - imageHeight}
               width={imageHeight} height={imageHeight}
               xlinkHref={person.avatar}>
             </image>
           } else {
-            image = <text x={rightColumn} y={topCenter + lineSep}>
+            image = <text x={imageX} y={bottomCenter - imageHeight + 1}>
               😐
             </text>
           }
-          return <a key={person.name} xlinkHref={person.url}>
+          return <a
+              key={person.name} xlinkHref={person.url}
+              clipPath={'url(#' + imageClipPath + ')'}>
             <title>{person.name}</title>
             {image}
           </a>
         });
+        people = <g>
+          <clipPath id={imageClipPath}>
+            <rect x={leftCenter} y={top} width={imageHeight * unclippedPeople.length} height={height} />
+          </clipPath>
+          {unclippedPeople}
+        </g>
       }
       if (this.props.comments) {
-        comments = <text x={rightColumn} y={topCenter + imageHeight + lineSep}>
+        comments = <text x={rightCenter - 9} y={bottomCenter - imageHeight + 1}>
           🗪{this.props.comments}
         </text>
       }
       if (this.props.tasks) {
-        tasks = <text x={rightColumn} y={topCenter + imageHeight + 2 * lineSep}>
+        tasks = <text x={rightCenter - 5} y={bottomCenter - imageHeight + 1}>
           ☑{this.props.tasksCompleted}/{this.props.tasks}
+        </text>
+      }
+      if (this.props.status) {
+        var statusIcon;
+        if (this.props.status === 'success') {
+          statusIcon = '✓';
+        } else if (this.props.status === 'failure') {
+          statusIcon = '⚠';
+        } else if (this.props.status === 'pending') {
+          statusIcon = '⌛';
+        } else {
+          throw new Error('unrecognized status: ' + this.props.status);
+        }
+        status = <text x={rightCenter - 1} y={bottomCenter - imageHeight + 1}>
+          <title>{this.props.status}</title>
+          {statusIcon}
         </text>
       }
     } else { /* collapsed */
@@ -233,9 +242,6 @@ class DepCard extends PureComponent {
     return <g className="DepCard" xmlnsXlink="http://www.w3.org/1999/xlink">
       <clipPath id={this.id('_full_width')}>
         <rect x={left} y={top} width={width} height={height} />
-      </clipPath>
-      <clipPath id={this.id('_left_column')}>
-        <rect x={left} y={top} width={rightColumn - left} height={height} />
       </clipPath>
       <rect
         x={left} y={top} width={width} height={height}
@@ -260,7 +266,7 @@ class DepCard extends PureComponent {
         <text
             x={leftCenter + imageHeight + 0.4}
             y={topCenter + 1}
-            clipPath={idClipPath}>
+            clipPath={fullWidthClipPath}>
           {this.props.slug.replace(/^[^\/]*\//, '')}
         </text>
       </a>
@@ -269,6 +275,7 @@ class DepCard extends PureComponent {
       {people}
       {comments}
       {tasks}
+      {status}
       <DepIndicators
         cx={right} cy={this.props.cy} dy={height/2}
         parents={this.props.parents}

--- a/webapp/src/DepCard.test.js
+++ b/webapp/src/DepCard.test.js
@@ -139,27 +139,64 @@ it('expanded with multiple labels renders without crashing', () => {
   );
 });
 
-it('expanded with no right column renders without crashing', () => {
+it('expanded success status renders without crashing', () => {
   const svg = document.createElement('svg');
-  const labels = [
-    {name: 'bug', 'color': '#ff0000'},
-    {name: 'help wanted', 'color': '#0000ff'},
-  ];
   ReactDOM.render(
     <DepCard
       cx={40} cy={30}
       host="github.com"
       slug="github.com/jbenet/depviz#1"
       title="depviz v0: single page rendering"
-      href="https://github.com/jbenet/depviz/issues/1"
-      dependencies={5}
-      related={1}
-      dependents={20}
       done={false}
-      labels={labels}
+      status="success"
       expanded={true} />,
     svg
   );
+});
+
+it('expanded failure status renders without crashing', () => {
+  const svg = document.createElement('svg');
+  ReactDOM.render(
+    <DepCard
+      cx={40} cy={30}
+      host="github.com"
+      slug="github.com/jbenet/depviz#1"
+      title="depviz v0: single page rendering"
+      done={false}
+      status="failure"
+      expanded={true} />,
+    svg
+  );
+});
+
+it('expanded pending status renders without crashing', () => {
+  const svg = document.createElement('svg');
+  ReactDOM.render(
+    <DepCard
+      cx={40} cy={30}
+      host="github.com"
+      slug="github.com/jbenet/depviz#1"
+      title="depviz v0: single page rendering"
+      done={false}
+      status="pending"
+      expanded={true} />,
+    svg
+  );
+});
+
+it('expanded example status crashes', () => {
+  const svg = document.createElement('svg');
+  expect(() => ReactDOM.render(
+    <DepCard
+      cx={40} cy={30}
+      host="github.com"
+      slug="github.com/jbenet/depviz#1"
+      title="depviz v0: single page rendering"
+      done={false}
+      status="example"
+      expanded={true} />,
+    svg
+  )).toThrowError('unrecognized status: example');
 });
 
 it('blocker count with some completed dependencies', () => {

--- a/webapp/src/DummyHost.js
+++ b/webapp/src/DummyHost.js
@@ -89,6 +89,19 @@ class GetDummyHostNodes {
       }
     };
 
+    var status = function (number) {
+      if (number % 4 === 0) {
+        return undefined;
+      }
+      if (number % 4 === 1) {
+        return 'success';
+      }
+      if (number % 4 === 2) {
+        return 'failure';
+      }
+      return 'pending';
+    }
+
     return new DepCard({
       ...props,
       slug: key,
@@ -96,6 +109,7 @@ class GetDummyHostNodes {
       title: 'dummy ' + key,
       href: `https://example.com/${data.user}/${data.repo}/issue/${data.number}`,
       done: done(data.number),
+      status: status(data.number),
       dependencies: dependencies(data.number),
       related: [],
       comments: data.number % 2 ? undefined : data.number,
@@ -105,10 +119,16 @@ class GetDummyHostNodes {
         {name: 'bug', color: '#ee0701'},
         {name: 'help wanted', color: '#84b6eb'},
       ],
-      people: [{
-        name: 'assignee' + data.number,
-        url: 'https://example.com/assignee' + data.number,
-      }],
+      people: [
+        {
+          name: 'assignee' + data.number,
+          url: 'https://example.com/assignee' + data.number,
+        },
+        {
+          name: 'assignee' + (data.number + 1),
+          url: 'https://example.com/assignee' + (data.number + 1),
+        }
+      ],
     })
   }
 

--- a/webapp/src/DummyHost.test.js
+++ b/webapp/src/DummyHost.test.js
@@ -62,3 +62,15 @@ it('user key fetches without crashing', () => {
   }
   return dummyGetter.GetNodes('dummy/jbenet', pushNodes);
 });
+
+it('non-status fetches without crashing', () => {
+  var nodes = [];
+  function pushNodes(newNodes) {
+    for (var index in newNodes) {
+      if (Object.prototype.hasOwnProperty.call(newNodes, index)) {
+        nodes.push(newNodes[index]);
+      }
+    }
+  }
+  return dummyGetter.GetNodes('dummy/jbenet/depviz#4', pushNodes);
+});

--- a/webapp/src/GitHub.js
+++ b/webapp/src/GitHub.js
@@ -38,16 +38,24 @@ export function CanonicalGitHubKey(key) {
   return key;
 }
 
-function nodeFromIssue(issue, props) {
-  var dependencies = [];
-  var related = [];
+function nodeFromIssue(issue, props, pushNodes) {
+  props = Object.assign({}, props);
+  props.host = 'github.com';
+  props.title = issue.title;
+  props.href = issue.html_url;
+  props.done = issue.state !== 'open';
+  props.comments = issue.comments;
   var regexp = /^depends +on +(?:([^ ]+)\/)?(?:([^ ]+))?(?:#([0-9]+)) *$/gim;
   // FIXME: look for related too
   var match;
   match = /^.*\/([^\/]+)\/([^\/]+)$/.exec(issue.repository_url);
   var issueUser = match[1];
   var issueRepo = match[2];
-  var key = 'github.com/' + issueUser + '/' + issueRepo + '#' + issue.number;
+  props.slug = (
+    'github.com/' + issueUser + '/' + issueRepo + '#' + issue.number
+  );
+  props.dependencies = [];
+  props.related = [];
   for (;;) {
     match = regexp.exec(issue.body);
     if (match === null) {
@@ -64,10 +72,10 @@ function nodeFromIssue(issue, props) {
       repo = issueRepo;
     }
     var relatedKey = 'github.com/' + user + '/' + repo + '#' + number;
-    dependencies.push(relatedKey);
+    props.dependencies.push(relatedKey);
   }
-  var tasks = 0;
-  var tasksCompleted = 0;
+  props.tasks = 0;
+  props.tasksCompleted = 0;
   regexp = /^[^[]*\[([ x])].*$/gm;
   for (;;) {
     match = regexp.exec(issue.body);
@@ -76,19 +84,18 @@ function nodeFromIssue(issue, props) {
     }
     var check = match[1];
     if (check === 'x') {
-      tasksCompleted += 1;
+      props.tasksCompleted += 1;
     }
-    tasks += 1;
+    props.tasks += 1;
   }
-  var labels = issue.labels.map(function (label) {
+  props.labels = issue.labels.map(function (label) {
     return {
       name: label.name,
       color: '#' + label.color,
     }
   });
-  var people;
   if (issue.assignees.length) {
-    people = issue.assignees.map(function (user) {
+    props.people = issue.assignees.map(function (user) {
       return {
         name: user.login,
         url: user.html_url,
@@ -96,27 +103,30 @@ function nodeFromIssue(issue, props) {
       }
     });
   } else {
-    people = [{
+    props.people = [{
       name: issue.user.login,
       url: issue.user.html_url,
       avatar: issue.user.avatar_url,
     }];
   }
-  return new DepCard({
-    ...props,
-    slug: key,
-    host: 'github.com',
-    title: issue.title,
-    href: issue.html_url,
-    done: issue.state !== 'open',
-    dependencies: dependencies,
-    related: related,
-    comments: issue.comments,
-    tasks: tasks,
-    tasksCompleted: tasksCompleted,
-    labels: labels,
-    people: people,
-  });
+  if (issue.pull_request && !props.done) {
+    // getCombinedStatus https://github.com/github-tools/github/pull/397
+    var _repo = gh.getRepo(issueUser, issueRepo);
+    _repo._request(
+      'GET',
+      `/repos/${_repo.__fullname}/commits/refs/pull/${issue.number}/head/status`,
+      null,
+      function (error, status) {
+        if (error) {
+          console.log('throw', error, status);
+          throw error;
+        }
+        props.status = status.state;
+        pushNodes([new DepCard(props)]);
+      }
+    );
+  }
+  return new DepCard(props);
 }
 
 function GetGitHubNodes(key, pushNodes, props) {
@@ -126,7 +136,7 @@ function GetGitHubNodes(key, pushNodes, props) {
       q: `assignee:${data.user} is:open`,
     }).then(function (issues) {
       var nodes = issues.data.map(function (issue) {
-        return nodeFromIssue(issue, props);
+        return nodeFromIssue(issue, props, pushNodes);
       });
       pushNodes(nodes);
     });
@@ -137,7 +147,7 @@ function GetGitHubNodes(key, pushNodes, props) {
     ).listIssues(
     ).then(function (issues) {
       var nodes = issues.data.map(function (issue) {
-        return nodeFromIssue(issue, props);
+        return nodeFromIssue(issue, props, pushNodes);
       });
       pushNodes(nodes);
     });
@@ -147,7 +157,7 @@ function GetGitHubNodes(key, pushNodes, props) {
   ).getIssue(
     data.number
   ).then(function (issue) {
-    pushNodes([nodeFromIssue(issue.data, props)]);
+    pushNodes([nodeFromIssue(issue.data, props, pushNodes)]);
   });
 }
 

--- a/webapp/src/GitHub.test.js
+++ b/webapp/src/GitHub.test.js
@@ -125,7 +125,7 @@ it('repository keys are understood', () => {
     GetGitHubNodes(
       'github.com/jbenet/depviz', pushNodes
     ).then(function() {
-      expect(nodes.length).toBe(2);
+      expect(nodes.length).toBe(3);
       resolve();
     }).catch(reject);
   });
@@ -144,8 +144,23 @@ it('user keys are understood', () => {
     GetGitHubNodes(
       'github.com/jbenet', pushNodes
     ).then(function() {
-      expect(nodes.length).toBe(2);
+      expect(nodes.length).toBe(3);
       resolve();
     }).catch(reject);
+  });
+});
+
+it('unsuccessful status request throws an error', () => {
+  var pushNodes = jest.fn();
+  return GetGitHubNodes(
+    'github.com/jbenet/depviz#99', pushNodes
+  ).then(function () {
+    throw new Error('GetGitHubNodes did not throw an error');
+  }).catch(function (error) {
+    expect(() => {
+      throw error;
+    }).toThrowError(
+      'error making request GET /repos/undefined/commits/refs/pull/99/head/status'
+    );
   });
 });


### PR DESCRIPTION
Using a separate call to the [GitHub API][1] for open pull requests, because GitHub doesn't expose this information directly in its issue response.  The hack access to `_request` works around the [currently-missing github-tools/github wrapper for this API endpoint][2].

We don't look this up for closed pull requests, because a separate per-issue request is expensive, and users are unlikely to care that much about the CI status of closed pull requests.  If it turns out that some do care, we'll have to make the done-ness filter configurable.

This commit also shuffles the expanded card from a two-column, three-line layout to a one-column, four-line layout (although the last line is split into a number of columns).  That gives us more space for multiple people and longer IDs/titles, keeps the cards at a reasonable size, and doesn't crowd too much.

Fixes #39.

[1]: https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
[2]: https://github.com/github-tools/github/pull/397